### PR TITLE
스크랩 순으로 정렬 구현 - 비동기

### DIFF
--- a/informations/views.py
+++ b/informations/views.py
@@ -32,7 +32,7 @@ def region_view(request):
         if align_mode == 'recently': # 최신순 정렬
             region = region.order_by('-created_at')
         else: # 인기순(스크랩순) 정렬
-            pass # **아직 스크랩 기능 안만들어서 일단 오래된순으로 보이게 해놓음**
+            region = region.order_by('-scrap')
             
         context = {
             'item_list' : region,
@@ -50,7 +50,7 @@ def multicultural_view(request):
         if align_mode == 'recently': # 최신순 정렬
             multicultural = multicultural.order_by('-created_at')
         else: # 인기순(스크랩순) 정렬
-            pass # **아직 스크랩 기능 안만들어서 일단 오래된순으로 보이게 해놓음**
+            multicultural = multicultural.order_by('-scrap')
         
         context = {
             'item_list' : multicultural,
@@ -68,7 +68,7 @@ def afterschool_view(request):
         if align_mode == 'recently': # 최신순 정렬
             afterschool = afterschool.order_by('-created_at')
         else: # 인기순(스크랩순) 정렬
-            pass # **아직 스크랩 기능 안만들어서 일단 오래된순으로 보이게 해놓음**
+            afterschool = afterschool.order_by('-scrap')
         
         context = {
             'item_list' : afterschool,

--- a/templates/informations/informations-afterschool.html
+++ b/templates/informations/informations-afterschool.html
@@ -32,34 +32,38 @@
 
 <form action="{% url 'informations:afterschool' %}" method="GET" id="align_mode_form">
     <select name="align_mode" id="align_mode">
-        <option value="recently">recently</option>
-        <option value="scrap">scrap</option>
+        <option value="recently">최신순</option>
+        <option value="scrap">스크랩순</option>
     </select>
 </form>
 
-{% for item in item_list %}
-    동명 : {{ item.region }}<br>
-    프로그램명 : {{ item.title }}<br>
-    접수일시 : {{ item.receipt_start }} ~ {{ item.receipt_end }}<br>
-    교육일시 : {{ item.training_start }} ~ {{ item.training_end }}<br>
-    요일 : {{ item.day }}<br>
-    수강료 : {{ item.tuition }}(원)<br>
-    정원 : {{ item.number_of_member }}명<br>
-    상태 : {{ item.status }}<br>
-    <button id="scrap-btn-{{ item.id }}" onclick="item_scrap({{ item.id }})">
-        {% if request.user in item.scrap.all %}
-        <!-- 로그인 한 유저가 좋아요를 누른 유저일때  -->
-        <i id="heart-{{ item.id }}" class="fas fa-heart"></i>
-        {%else%}
-        <!-- 로그인 한 유저가 좋아요를 누른 유저가 아닐 때  -->
-        <i id="heart-{{ item.id }}" class="far fa-heart"></i>
-        {%endif%}
-        <span id="scrap_count-{{ item.id }}">{{ item.scrap.count }}</span>
-    </button>
+<div id="item-container">
+    {% for item in item_list %}
+        <div class="item">
+            동명 : {{ item.region }}<br>
+            프로그램명 : {{ item.title }}<br>
+            접수일시 : {{ item.receipt_start }} ~ {{ item.receipt_end }}<br>
+            교육일시 : {{ item.training_start }} ~ {{ item.training_end }}<br>
+            요일 : {{ item.day }}<br>
+            수강료 : {{ item.tuition }}(원)<br>
+            정원 : {{ item.number_of_member }}명<br>
+            상태 : {{ item.status }}<br>
+            <button id="scrap-btn-{{ item.id }}" onclick="item_scrap({{ item.id }})">
+                {% if request.user in item.scrap.all %}
+                <!-- 로그인 한 유저가 좋아요를 누른 유저일때  -->
+                <i id="heart-{{ item.id }}" class="fas fa-heart"></i>
+                {%else%}
+                <!-- 로그인 한 유저가 좋아요를 누른 유저가 아닐 때  -->
+                <i id="heart-{{ item.id }}" class="far fa-heart"></i>
+                {%endif%}
+                <span class="scrap-count" id="scrap_count-{{ item.id }}">{{ item.scrap.count }}</span>
+            </button>
 
-    <br>
-    <br>
-{% endfor %}
+            <br>
+            <br>
+        </div>
+    {% endfor %}
+</div>
 
 <script src="https://code.jquery.com/jquery-3.5.1.js"
         integrity="sha256-QWo7LDvxbWT2tbbQ97B53yJnYU3WhH/C8ycbRAkjPDc=" crossorigin="anonymous"></script>
@@ -78,13 +82,42 @@
             }, // post_id 라는 name으로 id 값 전송
             dataType: "json",
             success: function (response) { // ajax 통신이 정상적으로 완료되었을 때
+                // $('#scrap_count-' + id).html(response.scrap_count);
+                // $('#message').html(response.message);
+                // if (response.message === "좋아요") {
+                //     $('#heart-' + id).attr("class", "fas fa-heart");
+                // } else if (response.message === "좋아요 취소") {
+                //     $('#heart-' + id).attr("class", "far fa-heart");
+                // }
+
                 $('#scrap_count-' + id).html(response.scrap_count);
                 $('#message').html(response.message);
-                $('.toast').fadeIn(400).delay(100).fadeOut(400);
+                
+                // 해당 항목의 좋아요 수만 업데이트
+                $('#scrap_count-' + id).html(response.scrap_count);
+                
+                // 좋아요 버튼 아이콘 변경
+                var heartIcon = $('#heart-' + id);
                 if (response.message === "좋아요") {
-                    $('#heart-' + id).attr("class", "fas fa-heart");
+                    heartIcon.removeClass("far fa-heart").addClass("fas fa-heart");
                 } else if (response.message === "좋아요 취소") {
-                    $('#heart-' + id).attr("class", "far fa-heart");
+                    heartIcon.removeClass("fas fa-heart").addClass("far fa-heart");
+                }
+                
+                // 좋아요 수에 따라 항목을 정렬 (jQuery 이용)
+                var itemContainer = $('#item-container');  // 항목을 감싸는 컨테이너의 ID
+                var alignMode = $('#align_mode').val(); // 선택된 정렬 모드 가져오기
+    
+                if (alignMode === 'scrap') {
+                    var items = itemContainer.children('.item');  // 항목들을 선택
+        
+                    items.sort(function(a, b) {
+                        var aScrapCount = parseInt($(a).find('.scrap-count').text());
+                        var bScrapCount = parseInt($(b).find('.scrap-count').text());
+                        return bScrapCount - aScrapCount;  // 내림차순 정렬
+                    });
+                    
+                    itemContainer.html(items);  // 정렬된 항목을 컨테이너에 적용
                 }
             }
         });

--- a/templates/informations/informations-multicultural.html
+++ b/templates/informations/informations-multicultural.html
@@ -32,33 +32,37 @@
 
 <form action="{% url 'informations:multicultural' %}" method="GET" id="align_mode_form">
     <select name="align_mode" id="align_mode">
-        <option value="recently">recently</option>
-        <option value="scrap">scrap</option>
+        <option value="recently">최신순</option>
+        <option value="scrap">스크랩순</option>
     </select>
 </form>
 
-{% for item in item_list %}
-    제목 : {{ item.title }}<br>
-    내용 : {{ item.content }}<br>
-    문의처 : {{ item.phone }}<br>
-    지원 주기 : {{ item.support_cycle }}<br>
-    제공 유형 : {{ item.type }}<br>
-    담당 부서 : {{ item.department }}<br>
-    태그 : {{ item.tag }}<br>
-    <button id="scrap-btn-{{ item.id }}" onclick="item_scrap({{ item.id }})">
-        {% if request.user in item.scrap.all %}
-        <!-- 로그인 한 유저가 좋아요를 누른 유저일때  -->
-        <i id="heart-{{ item.id }}" class="fas fa-heart"></i>
-        {%else%}
-        <!-- 로그인 한 유저가 좋아요를 누른 유저가 아닐 때  -->
-        <i id="heart-{{ item.id }}" class="far fa-heart"></i>
-        {%endif%}
-        <span id="scrap_count-{{ item.id }}">{{ item.scrap.count }}</span>
-    </button>
+<div id="item-container">
+    {% for item in item_list %}
+        <div class="item">
+            제목 : {{ item.title }}<br>
+            내용 : {{ item.content }}<br>
+            문의처 : {{ item.phone }}<br>
+            지원 주기 : {{ item.support_cycle }}<br>
+            제공 유형 : {{ item.type }}<br>
+            담당 부서 : {{ item.department }}<br>
+            태그 : {{ item.tag }}<br>
+            <button id="scrap-btn-{{ item.id }}" onclick="item_scrap({{ item.id }})">
+                {% if request.user in item.scrap.all %}
+                <!-- 로그인 한 유저가 좋아요를 누른 유저일때  -->
+                <i id="heart-{{ item.id }}" class="fas fa-heart"></i>
+                {%else%}
+                <!-- 로그인 한 유저가 좋아요를 누른 유저가 아닐 때  -->
+                <i id="heart-{{ item.id }}" class="far fa-heart"></i>
+                {%endif%}
+                <span class="scrap-count" id="scrap_count-{{ item.id }}">{{ item.scrap.count }}</span>
+            </button>
 
-    <br>
-    <br>
-{% endfor %}
+            <br>
+            <br>
+        </div>
+    {% endfor %}
+</div>
 
 <script src="https://code.jquery.com/jquery-3.5.1.js"
         integrity="sha256-QWo7LDvxbWT2tbbQ97B53yJnYU3WhH/C8ycbRAkjPDc=" crossorigin="anonymous"></script>
@@ -77,13 +81,42 @@
             }, // post_id 라는 name으로 id 값 전송
             dataType: "json",
             success: function (response) { // ajax 통신이 정상적으로 완료되었을 때
+                // $('#scrap_count-' + id).html(response.scrap_count);
+                // $('#message').html(response.message);
+                // if (response.message === "좋아요") {
+                //     $('#heart-' + id).attr("class", "fas fa-heart");
+                // } else if (response.message === "좋아요 취소") {
+                //     $('#heart-' + id).attr("class", "far fa-heart");
+                // }
+
                 $('#scrap_count-' + id).html(response.scrap_count);
                 $('#message').html(response.message);
-                $('.toast').fadeIn(400).delay(100).fadeOut(400);
+                
+                // 해당 항목의 좋아요 수만 업데이트
+                $('#scrap_count-' + id).html(response.scrap_count);
+                
+                // 좋아요 버튼 아이콘 변경
+                var heartIcon = $('#heart-' + id);
                 if (response.message === "좋아요") {
-                    $('#heart-' + id).attr("class", "fas fa-heart");
+                    heartIcon.removeClass("far fa-heart").addClass("fas fa-heart");
                 } else if (response.message === "좋아요 취소") {
-                    $('#heart-' + id).attr("class", "far fa-heart");
+                    heartIcon.removeClass("fas fa-heart").addClass("far fa-heart");
+                }
+                
+                // 좋아요 수에 따라 항목을 정렬 (jQuery 이용)
+                var itemContainer = $('#item-container');  // 항목을 감싸는 컨테이너의 ID
+                var alignMode = $('#align_mode').val(); // 선택된 정렬 모드 가져오기
+    
+                if (alignMode === 'scrap') {
+                    var items = itemContainer.children('.item');  // 항목들을 선택
+        
+                    items.sort(function(a, b) {
+                        var aScrapCount = parseInt($(a).find('.scrap-count').text());
+                        var bScrapCount = parseInt($(b).find('.scrap-count').text());
+                        return bScrapCount - aScrapCount;  // 내림차순 정렬
+                    });
+                    
+                    itemContainer.html(items);  // 정렬된 항목을 컨테이너에 적용
                 }
             }
         });

--- a/templates/informations/informations-region.html
+++ b/templates/informations/informations-region.html
@@ -31,33 +31,37 @@
 
 <form action="{% url 'informations:region' %}" method="GET" id="align_mode_form">
         <select name="align_mode" id="align_mode">
-            <option value="recently">recently</option>
-            <option value="scrap">scrap</option>
+            <option value="recently">최신순</option>
+            <option value="scrap">스크랩순</option>
         </select>
 </form>
 
-{% for item in item_list %}
-    제목 : {{ item.title }}<br>
-    내용 : {{ item.content }}<br>
-    문의처 : {{ item.phone }}<br>
-    지원 주기 : {{ item.support_cycle }}<br>
-    제공 유형 :{{ item.type }}<br>
-    담당 부서 : {{ item.department }}<br>
-    태그 : {{ item.tag }}<br>
-    <button id="scrap-btn-{{ item.id }}" onclick="item_scrap({{ item.id }})">
-        {% if request.user in item.scrap.all %}
-        <!-- 로그인 한 유저가 좋아요를 누른 유저일때  -->
-        <i id="heart-{{ item.id }}" class="fas fa-heart"></i>
-        {%else%}
-        <!-- 로그인 한 유저가 좋아요를 누른 유저가 아닐 때  -->
-        <i id="heart-{{ item.id }}" class="far fa-heart"></i>
-        {%endif%}
-        <span id="scrap_count-{{ item.id }}">{{ item.scrap.count }}</span>
-    </button>
+<div id="item-container">
+    {% for item in item_list %}
+        <div class="item">
+            제목 : {{ item.title }}<br>
+            내용 : {{ item.content }}<br>
+            문의처 : {{ item.phone }}<br>
+            지원 주기 : {{ item.support_cycle }}<br>
+            제공 유형 :{{ item.type }}<br>
+            담당 부서 : {{ item.department }}<br>
+            태그 : {{ item.tag }}<br>
+            <button id="scrap-btn-{{ item.id }}" onclick="item_scrap({{ item.id }})">
+                {% if request.user in item.scrap.all %}
+                <!-- 로그인 한 유저가 좋아요를 누른 유저일때  -->
+                <i id="heart-{{ item.id }}" class="fas fa-heart"></i>
+                {%else%}
+                <!-- 로그인 한 유저가 좋아요를 누른 유저가 아닐 때  -->
+                <i id="heart-{{ item.id }}" class="far fa-heart"></i>
+                {%endif%}
+                <span class="scrap-count" id="scrap_count-{{ item.id }}">{{ item.scrap.count }}</span>
+            </button>
 
-    <br>
-    <br>
-{% endfor %}
+            <br>
+            <br>
+        </div>
+    {% endfor %}
+</div>
 
 <script src="https://code.jquery.com/jquery-3.5.1.js"
         integrity="sha256-QWo7LDvxbWT2tbbQ97B53yJnYU3WhH/C8ycbRAkjPDc=" crossorigin="anonymous"></script>
@@ -76,13 +80,41 @@
             }, // post_id 라는 name으로 id 값 전송
             dataType: "json",
             success: function (response) { // ajax 통신이 정상적으로 완료되었을 때
+                // $('#scrap_count-' + id).html(response.scrap_count);
+                // $('#message').html(response.message);
+                // if (response.message === "좋아요") {
+                //     $('#heart-' + id).attr("class", "fas fa-heart");
+                // } else if (response.message === "좋아요 취소") {
+                //     $('#heart-' + id).attr("class", "far fa-heart");
+                // }
+
                 $('#scrap_count-' + id).html(response.scrap_count);
                 $('#message').html(response.message);
-                $('.toast').fadeIn(400).delay(100).fadeOut(400);
+                
+                // 해당 항목의 좋아요 수만 업데이트
+                $('#scrap_count-' + id).html(response.scrap_count);
+                
+                // 좋아요 버튼 아이콘 변경
+                var heartIcon = $('#heart-' + id);
                 if (response.message === "좋아요") {
-                    $('#heart-' + id).attr("class", "fas fa-heart");
+                    heartIcon.removeClass("far fa-heart").addClass("fas fa-heart");
                 } else if (response.message === "좋아요 취소") {
-                    $('#heart-' + id).attr("class", "far fa-heart");
+                    heartIcon.removeClass("fas fa-heart").addClass("far fa-heart");
+                }
+                
+                // 좋아요 수에 따라 항목을 정렬 (jQuery 이용)
+                var itemContainer = $('#item-container');  // 항목을 감싸는 컨테이너의 ID
+                var alignMode = $('#align_mode').val(); // 선택된 정렬 모드 가져오기
+    
+                if (alignMode === 'scrap') {
+                    var items = itemContainer.children('.item');  // 항목들을 선택
+        
+                    items.sort(function(a, b) {
+                        var aScrapCount = parseInt($(a).find('.scrap-count').text());
+                        var bScrapCount = parseInt($(b).find('.scrap-count').text());
+                    });
+                    
+                    itemContainer.html(items);  // 정렬된 항목을 컨테이너에 적용
                 }
             }
         });


### PR DESCRIPTION
close #20 

<br>

**[ 주요 변경 사항 ]**
* informations 앱의 views.py 수정 : order_by 이용해서 스크랩 정렬
* informations 앱에 해당하는 html 수정 : 좋아요 버튼 눌리거나 취소될 때 마다 해당 item들 업데이트

<br>

**[ 기타 사항 ]**
* 자잘한 문구 및 오류 수정
* 스크랩 수가 같다면 최신순으로 정렬 .. (잘 안됨)

<br>

**[ 실행 결과 ]**
- 각 하위페이지에서 스크랩 순 정렬 기능 확인 가능
- align_mode 변경해도 하트 유지됨
- 아래는 region 예시, multicultural, aftershcool도 동일
<img width="1193" alt="스크린샷 2023-08-12 오후 3 15 05" src="https://github.com/Likelion-All-Together/all-together/assets/98332877/8b33e6c0-4028-4878-8699-71556d346204">
<img width="1193" alt="스크린샷 2023-08-12 오후 3 16 20" src="https://github.com/Likelion-All-Together/all-together/assets/98332877/ce8bd0d5-9cde-4f76-9801-972b28bc8b82">